### PR TITLE
fix: add permissions section to commitlint and markdownlint workflows

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -2,6 +2,9 @@ name: Lint Commit Messages
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   commitlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -2,6 +2,9 @@ name: Lint Markdown
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 📝 Description

Updated the permissions of Markdown and Commit Lint GH Action Workflow

## 💡 Type of Change

Please delete options that are not relevant.

- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🎨 Style/UI update (CSS, layout, or design changes)
- [x] 🐞 Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 Refactor (code cleanup or structural changes)
- [ ] 📝 Documentation update

## 📸 Screenshots (If applicable)

*Place screenshots or GIFs here to show the visual changes.*

## ✅ Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new console errors or warnings.
- [ ] (Optional) I have tested the responsiveness on mobile/tablet.
